### PR TITLE
Update CrossStitch to Minecraft 1.19.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.19
-yarn_mappings=1.19+build.4
-loader_version=0.14.8
+minecraft_version=1.19.3
+yarn_mappings=1.19.3+build.3
+loader_version=0.14.11
 
 #Fabric api
-fabric_version=0.56.0+1.198
+fabric_version=0.69.1+1.19.3
 # Mod Properties
-mod_version=0.1.5
+mod_version=0.2.0
 maven_group=com.velocitypowered
 archives_base_name=crossstitch
 

--- a/src/main/java/com/velocitypowered/crossstitch/mixin/command/CommandTreeSerializationMixin.java
+++ b/src/main/java/com/velocitypowered/crossstitch/mixin/command/CommandTreeSerializationMixin.java
@@ -4,8 +4,8 @@ import com.mojang.brigadier.arguments.ArgumentType;
 import io.netty.buffer.Unpooled;
 import net.minecraft.command.argument.serialize.ArgumentSerializer;
 import net.minecraft.network.PacketByteBuf;
-import net.minecraft.util.registry.Registry;
-import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKey;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,7 +23,7 @@ public class CommandTreeSerializationMixin {
     @Inject(method = "write(Lnet/minecraft/network/PacketByteBuf;Lnet/minecraft/command/argument/serialize/ArgumentSerializer;Lnet/minecraft/command/argument/serialize/ArgumentSerializer$ArgumentTypeProperties;)V",
             at = @At("HEAD"), cancellable = true)
     private static <A extends ArgumentType<?>, T extends ArgumentSerializer.ArgumentTypeProperties<A>> void writeNode$wrapInVelocityModArgument(PacketByteBuf buf, ArgumentSerializer<A, T> serializer, ArgumentSerializer.ArgumentTypeProperties<A> properties, CallbackInfo ci) {
-        Optional<RegistryKey<ArgumentSerializer<?, ?>>> entry = Registry.COMMAND_ARGUMENT_TYPE.getKey(serializer);
+        Optional<RegistryKey<ArgumentSerializer<?, ?>>> entry = Registries.COMMAND_ARGUMENT_TYPE.getKey(serializer);
 
         if (entry.isEmpty()) {
             return;
@@ -41,7 +41,7 @@ public class CommandTreeSerializationMixin {
 
     private static <A extends ArgumentType<?>, T extends ArgumentSerializer.ArgumentTypeProperties<A>> void serializeWrappedArgumentType(PacketByteBuf packetByteBuf, ArgumentSerializer<A, T> serializer, ArgumentSerializer.ArgumentTypeProperties<A> properties) {
         packetByteBuf.writeVarInt(MOD_ARGUMENT_INDICATOR);
-        packetByteBuf.writeVarInt(Registry.COMMAND_ARGUMENT_TYPE.getRawId(serializer));
+        packetByteBuf.writeVarInt(Registries.COMMAND_ARGUMENT_TYPE.getRawId(serializer));
 
         PacketByteBuf extraData = new PacketByteBuf(Unpooled.buffer());
         serializer.writePacket((T) properties, extraData);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,6 +19,6 @@
   ],
   "depends": {
     "fabricloader": ">=0.11",
-    "minecraft": ">=1.19"
+    "minecraft": ">=1.19.3"
   }
 }


### PR DESCRIPTION
Minecraft 1.19.3 introduced some minor changes to the registry classes. This is not backwards compatible with 1.19.2.